### PR TITLE
chore: release version 1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "theToyBox" extension will be documented in this file.
 
+## [1.1.9]
+
+- **Bug Fix**: **Save as PDF — Tables in Markdown now always render correctly** — Tables were silently dropped when exporting Markdown files saved with Windows line endings (CRLF). Line endings are now normalised before rendering, so tables appear correctly regardless of how the file was saved.
+- **Improvement**: **Save as PDF — Table layout and styling improvements** — Table columns now size themselves to fit their content rather than dividing the page width equally. Inline code inside table cells is styled correctly. Cell padding and row spacing are more consistent.
+- **New Feature**: **Save as PDF — HTTP and Shell/Bash syntax highlighting** — Code blocks tagged as `http`, `https`, `bash`, `sh`, or `shell` now receive syntax colouring in the exported PDF. HTTP request lines, headers, status codes, and URL parameters each use distinct colours; shell variables, flags, quoted strings, and keywords are styled appropriately.
+- **Bug Fix**: **Save as PDF — Mermaid diagrams with blank lines now render correctly** — Mermaid sequence diagrams (and any fenced code block containing blank lines) were being split in half during rendering, which produced a syntax error and caused the diagram to appear as plain text. Fenced code blocks are now kept intact regardless of their internal blank lines.
+
 ## [1.1.8]
 
 - **Improvement**: **Save as PDF — Mermaid diagrams now appear in exported PDFs** — Markdown files containing `mermaid` fenced code blocks are now fully rendered before export. The diagrams are rendered live in a temporary webview using the Mermaid library, each diagram is rasterized to an image, and the images are embedded directly in the PDF output. If a diagram fails to render, the source text appears as a fallback.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Export any open file to a PDF directly from the editor — no browser, no print 
 
 - **Toolbar Icon** — The **export** icon appears in the editor title bar when a Markdown or HTML file is open. Click it to go straight to the save dialog.
 - **Right-Click Export** — Right-click anywhere in the editor (or on a file in the Explorer) and choose **"The Toy Box: Save as PDF"**.
-- **Markdown files** are fully rendered before export — headings, bold and italic, tables, code blocks, task lists, blockquotes, GitHub-style alerts, links, and horizontal rules all appear in the PDF exactly as they do in the preview. Mermaid diagrams (` ```mermaid ` blocks) are rendered live and embedded as images.
+- **Markdown files** are fully rendered before export — headings, bold and italic, tables, code blocks, task lists, blockquotes, GitHub-style alerts, links, horizontal rules, and Mermaid diagrams all appear in the PDF. Code blocks use syntax colouring for a wide range of languages including JavaScript, TypeScript, PHP, ASP, nginx, SQL, HTTP, and Bash/Shell.
 - **HTML files** are rendered in a temporary webview so your CSS and JavaScript apply before the content is captured. SVG elements are converted to images so charts and icons appear in the PDF.
 - **Source code files** are exported with line numbers and syntax-aware coloring using a print-friendly dark-on-white palette.
 - Works on any OS — everything is generated inside VS Code with no external dependencies.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "theToyBox",
 	"displayName": "The Toy Box",
 	"description": "The Toy Box is a VS Code extension that bundles essential productivity tools: auto-cleanup on save, a smarter code outline for SQL/PHP/Web, custom comment highlighting, GitHub-style Markdown alerts, JSON formatting, equals alignment, real-time HTML/XML tag renaming, and Quick Notes — all in one package.",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"publisher": "ThomasDromgoole",
 	"repository": {
 		"type": "git",
@@ -51,7 +51,10 @@
 		"pdf",
 		"save as pdf",
 		"mermaid",
-		"diagram"
+		"diagram",
+		"http",
+		"bash",
+		"shell"
 	],
 	"extensionDependencies": [
 		"vscode.markdown-language-features"

--- a/src/codeTokenizer.ts
+++ b/src/codeTokenizer.ts
@@ -1,0 +1,131 @@
+/**
+ * codeTokenizer.ts
+ *
+ * Shared syntax-highlighting helpers used by both the code PDF printer
+ * (printer.ts) and the markdown PDF renderer (markdownToPdf.ts).
+ */
+
+import type { TokenMatch } from "./syntax/types";
+import { tokenizeKdl } from "./syntax/kdl";
+import { tokenizeAsp } from "./syntax/asp";
+import { tokenizeRazorVb } from "./syntax/razorVb";
+import { tokenizePhpSql } from "./syntax/phpSql";
+import { tokenizeJsSql } from "./syntax/jsSql";
+import { tokenizeNginx } from "./syntax/nginx";
+import { tokenizeHttp } from "./syntax/http";
+import { tokenizeShell } from "./syntax/shell";
+
+export interface StyledRun {
+	text: string;
+	color?: string;
+	bold?: boolean;
+	italic?: boolean;
+}
+
+export const TOKEN_COLORS: Record<string, string> = {
+	comment: "#57A64A",
+	string: "#D69D85",
+	number: "#B5CEA8",
+	boolean: "#569CD6",
+	typeAnnotation: "#4EC9B0",
+	nodeName: "#4FC1FF",
+	propKey: "#9CDCFE",
+	keyword: "#569CD6",
+	vbType: "#4EC9B0",
+	htmlTag: "#569CD6",
+	htmlAttribute: "#FF8C69",
+	htmlString: "#D69D85",
+	aspDelimiter: "#DCDCAA",
+	razorDelimiter: "#DCDCAA",
+	razorDirective: "#CE9178",
+	sqlKeyword: "#569CD6",
+	sqlType: "#4EC9B0",
+	sqlFunction: "#DCDCAA",
+	sqlVariable: "#9CDCFE",
+	nginxVariable: "#9CDCFE",
+	nginxBlock: "#4EC9B0",
+	httpMethod: "#8250df",
+	httpPath: "#0969da",
+	httpVersion: "#57606a",
+	httpStatus2xx: "#1a7f37",
+	httpStatus4xx: "#cf222e",
+	httpHeaderName: "#0550ae",
+	httpHeaderValue: "#57606a",
+	httpParamKey: "#0550ae",
+	shellVar: "#8250df",
+	shellString: "#0a3069",
+	shellFlag: "#0969da",
+};
+
+export const TOKEN_BOLD = new Set([
+	"nodeName",
+	"aspDelimiter",
+	"razorDelimiter",
+	"nginxBlock",
+]);
+
+export const TOKEN_ITALIC = new Set(["comment", "razorDirective"]);
+
+export const CODE_TOKENIZERS: Array<{
+	extensions: string[];
+	tokenize: (text: string) => TokenMatch[];
+}> = [
+	{ extensions: [".kdl"], tokenize: tokenizeKdl },
+	{ extensions: [".asp"], tokenize: tokenizeAsp },
+	{ extensions: [".vbhtml"], tokenize: tokenizeRazorVb },
+	{ extensions: [".php"], tokenize: tokenizePhpSql },
+	{
+		extensions: [".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"],
+		tokenize: tokenizeJsSql,
+	},
+	{ extensions: [".conf"], tokenize: tokenizeNginx },
+	{ extensions: [".http"], tokenize: tokenizeHttp },
+	{ extensions: [".sh", ".bash"], tokenize: tokenizeShell },
+];
+
+export function buildStyledRuns(
+	text: string,
+	tokens: TokenMatch[],
+): StyledRun[] {
+	const sorted = [...tokens].sort((a, b) => a.start - b.start);
+	const runs: StyledRun[] = [];
+	let pos = 0;
+
+	for (const token of sorted) {
+		if (pos < token.start) {
+			runs.push({ text: text.slice(pos, token.start) });
+		}
+		runs.push({
+			text: text.slice(token.start, token.end),
+			color: TOKEN_COLORS[token.type],
+			bold: TOKEN_BOLD.has(token.type) || undefined,
+			italic: TOKEN_ITALIC.has(token.type) || undefined,
+		});
+		pos = token.end;
+	}
+
+	if (pos < text.length) {
+		runs.push({ text: text.slice(pos) });
+	}
+
+	return runs;
+}
+
+/** Splits an array of styled runs into per-line arrays, respecting multi-line tokens. */
+export function runsToLines(runs: StyledRun[]): StyledRun[][] {
+	const lines: StyledRun[][] = [[]];
+
+	for (const run of runs) {
+		const parts = run.text.split("\n");
+		for (let i = 0; i < parts.length; i++) {
+			if (i > 0) {
+				lines.push([]);
+			}
+			if (parts[i].length > 0) {
+				lines[lines.length - 1].push({ ...run, text: parts[i] });
+			}
+		}
+	}
+
+	return lines;
+}

--- a/src/markdownRenderer.ts
+++ b/src/markdownRenderer.ts
@@ -91,6 +91,9 @@ function buildList(markdown: string, ordered: boolean): string {
  * Returns only the inner body content — no `<html>` / `<head>` wrapper.
  */
 export function renderMarkdownToHtml(markdown: string): string {
+	// Normalize line endings so all regexes below can assume LF only
+	markdown = markdown.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
 	// ── Pass 1: extract GitHub-style alerts ──────────────────────────────────
 	const lines = markdown.split("\n");
 	let result = "";
@@ -268,17 +271,14 @@ export function renderMarkdownToHtml(markdown: string): string {
 	markdown = markdown.replace(/\*([^*]+)\*/g, "<em>$1</em>");
 	markdown = markdown.replace(/~~([^~]+)~~/g, "<del>$1</del>");
 
-	// Restore inline code and code blocks
+	// Restore inline code
 	markdown = markdown.replace(
 		/%%INLINECODE_(\d+)%%/g,
 		(_m, i) => inlineCodes[Number(i)],
 	);
-	markdown = markdown.replace(
-		/%%CODEBLOCK_(\d+)%%/g,
-		(_m, i) => codeBlocks[Number(i)],
-	);
 
-	// Paragraphs
+	// Paragraphs — code block placeholders must be restored AFTER this step so
+	// blank lines inside fenced blocks don't get split into separate paragraphs.
 	markdown = markdown
 		.split(/\n{2,}/)
 		.map((para) => {
@@ -288,7 +288,7 @@ export function renderMarkdownToHtml(markdown: string): string {
 			}
 			if (
 				para.match(
-					/^<(?:h[1-6]|p|pre|div|ul|ol|li|table|thead|tbody|tr|th|td|hr|img|blockquote)/i,
+					/^(?:<(?:h[1-6]|p|pre|div|ul|ol|li|table|thead|tbody|tr|th|td|hr|img|blockquote)|%%CODEBLOCK)/i,
 				)
 			) {
 				return para;
@@ -297,6 +297,12 @@ export function renderMarkdownToHtml(markdown: string): string {
 		})
 		.filter(Boolean)
 		.join("\n");
+
+	// Restore code blocks
+	markdown = markdown.replace(
+		/%%CODEBLOCK_(\d+)%%/g,
+		(_m, i) => codeBlocks[Number(i)],
+	);
 
 	return markdown;
 }

--- a/src/markdownToPdf.ts
+++ b/src/markdownToPdf.ts
@@ -23,6 +23,12 @@
 import { assemblePdf as _unused, PdfImage } from "./pdfAssembler"; // keep import tree connected
 export { assemblePdf } from "./pdfAssembler";
 export type { PdfImage } from "./pdfAssembler";
+import {
+	StyledRun,
+	CODE_TOKENIZERS,
+	buildStyledRuns,
+	runsToLines,
+} from "./codeTokenizer";
 
 // ─── Page geometry ────────────────────────────────────────────────────────────
 const W = 595; // A4 width  pts
@@ -93,6 +99,29 @@ const ALERT_TITLE_C: Record<string, string> = {
 	important: pdfRgb("#6639ba"),
 	warning: pdfRgb("#7d4e00"),
 	caution: pdfRgb("#a40e26"),
+};
+
+// Maps fenced-code-block language identifiers to the extensions CODE_TOKENIZERS recognises
+const LANG_TO_EXT: Record<string, string> = {
+	js: ".js",
+	javascript: ".js",
+	mjs: ".js",
+	cjs: ".js",
+	ts: ".ts",
+	typescript: ".ts",
+	jsx: ".jsx",
+	tsx: ".tsx",
+	kdl: ".kdl",
+	asp: ".asp",
+	vbhtml: ".vbhtml",
+	php: ".php",
+	nginx: ".conf",
+	conf: ".conf",
+	http: ".http",
+	https: ".http",
+	bash: ".bash",
+	sh: ".sh",
+	shell: ".sh",
 };
 
 // ─── PDF string escape ────────────────────────────────────────────────────────
@@ -229,7 +258,7 @@ function parseInlineHtml(html: string): InlineSpan[] {
 type BlockType =
 	| { kind: "h"; level: number; html: string }
 	| { kind: "p"; html: string }
-	| { kind: "pre"; text: string }
+	| { kind: "pre"; text: string; lang?: string }
 	| { kind: "hr" }
 	| { kind: "ul"; items: string[] }
 	| { kind: "ol"; items: string[]; start: number }
@@ -334,12 +363,15 @@ function extractBlocks(html: string): BlockType[] {
 		const preMatch = html
 			.slice(i)
 			.match(
-				/^<pre(?:[^>]*)>(?:<code(?:[^>]*)>)?([\s\S]*?)(?:<\/code>)?<\/pre>/i,
+				/^<pre(?:[^>]*)>(<code(?:[^>]*)>)?([\s\S]*?)(?:<\/code>)?<\/pre>/i,
 			);
 		if (preMatch) {
+			const codeTag = preMatch[1] ?? "";
+			const langMatch = codeTag.match(/class="language-([^"\s]+)"/i);
 			blocks.push({
 				kind: "pre",
-				text: preMatch[1]
+				lang: langMatch?.[1],
+				text: preMatch[2]
 					.replace(/&amp;/g, "&")
 					.replace(/&lt;/g, "<")
 					.replace(/&gt;/g, ">")
@@ -727,20 +759,53 @@ export function buildMarkdownPdfPages(
 			}
 
 			case "pre": {
-				const codeLines = block.text.split("\n");
-				const blockH = codeLines.length * CODE_LH + 16;
+				const ext = LANG_TO_EXT[(block.lang ?? "").toLowerCase()] ?? "";
+				const profile = ext
+					? CODE_TOKENIZERS.find((p) => p.extensions.includes(ext))
+					: undefined;
+				const lineRuns: StyledRun[][] = profile
+					? runsToLines(
+							buildStyledRuns(
+								block.text,
+								profile.tokenize(block.text),
+							),
+						)
+					: block.text
+							.split("\n")
+							.map((l) => (l ? [{ text: l }] : []));
+
+				const lineCount = lineRuns.length;
+				const blockH = lineCount * CODE_LH + 16;
 				needSpace(Math.min(blockH, (H - MY * 2) / 2));
-				// Light gray background for code blocks
 				parts.push(
 					`q\n0.965 0.969 0.976 rg\n` +
-						`${MX} ${y - codeLines.length * CODE_LH - 8} ${CW} ${codeLines.length * CODE_LH + 16} re f\nQ\n`,
+						`${MX} ${y - lineCount * CODE_LH - 8} ${CW} ${lineCount * CODE_LH + 16} re f\nQ\n`,
 				);
 				y -= 8;
-				for (const line of codeLines) {
+				for (const runs of lineRuns) {
 					needSpace(CODE_LH);
-					parts.push(
-						`BT\n/F5 ${CODE_FS} Tf\n${MX + 8} ${y} Td\n${C_CODE} rg (${esc(line)}) Tj\nET\n`,
-					);
+					if (runs.length > 0) {
+						parts.push(`BT\n${MX + 8} ${y} Td\n`);
+						for (const run of runs) {
+							const font =
+								run.bold && run.italic
+									? "F8"
+									: run.bold
+										? "F6"
+										: run.italic
+											? "F7"
+											: "F5";
+							const color = run.color
+								? pdfRgb(run.color)
+								: profile
+									? C_BODY
+									: C_CODE;
+							parts.push(
+								`/${font} ${CODE_FS} Tf\n${color} rg (${esc(run.text)}) Tj\n`,
+							);
+						}
+						parts.push(`ET\n`);
+					}
 					y -= CODE_LH;
 				}
 				y -= 8;
@@ -808,40 +873,122 @@ export function buildMarkdownPdfPages(
 					break;
 				}
 				const colCount = allRows[0].cells.length;
-				const colW = (CW - 2) / colCount;
+				const HPAD = 6;
+				const ROW_ASCENT = 10; // pts above first-line baseline inside row
+				const ROW_DESCENT = 5; // pts below last-line baseline inside row
+
+				// Distribute column widths proportional to max natural content width
+				const colMaxW = Array<number>(colCount).fill(0);
 				for (const row of allRows) {
-					needSpace(BODY_LH + 4);
-					// Row background: header = light blue-gray, body = very light gray
-					parts.push(
-						`q\n${row.header ? "0.922 0.933 0.945 rg" : "0.980 0.980 0.980 rg"}\n` +
-							`${MX} ${y - BODY_LH - 2} ${CW} ${BODY_LH + 6} re f\nQ\n`,
-					);
 					row.cells.forEach((cell, ci) => {
-						const cx = MX + ci * colW + 4;
-						const spans = parseInlineHtml(cell);
-						let tx = cx;
-						parts.push(`BT\n`);
-						for (const sp of spans) {
-							if (!sp.text) {
-								continue;
-							}
-							const font = bodyFont(
-								row.header || sp.bold,
-								sp.italic,
-							);
-							parts.push(
-								`/${font} ${BODY_FS} Tf\n${tx} ${y} Td\n${row.header ? C_HEAD : C_BODY} rg (${esc(sp.text.slice(0, 30))}) Tj\n`,
-							);
-							tx += approxWidth(
-								sp.text.slice(0, 30),
-								BODY_FS,
-								false,
-							);
-						}
-						parts.push(`ET\n`);
+						const w = parseInlineHtml(cell).reduce(
+							(s, sp) =>
+								s + approxWidth(sp.text, BODY_FS, sp.code),
+							0,
+						);
+						colMaxW[ci] = Math.max(colMaxW[ci], w);
 					});
-					y -= BODY_LH + 4;
 				}
+				const totalMaxW = colMaxW.reduce((a, b) => a + b, 0) || 1;
+				// each column gets at least half of an equal-split share
+				const minColW = CW / (colCount * 2);
+				let colWs = colMaxW.map((w) =>
+					Math.max((w / totalMaxW) * CW, minColW),
+				);
+				const scaleW = CW / colWs.reduce((a, b) => a + b, 0);
+				colWs = colWs.map((w) => w * scaleW);
+
+				let pastHeader = false;
+
+				for (const row of allRows) {
+					const isFirstBody = !row.header && !pastHeader;
+					if (!row.header) pastHeader = true;
+
+					const wrapped = row.cells.map((cell, ci) =>
+						wrapInlineSpans(
+							parseInlineHtml(cell),
+							colWs[ci] - HPAD * 2,
+							BODY_FS,
+						),
+					);
+					const maxLines = Math.max(
+						1,
+						...wrapped.map((w) => w.length),
+					);
+					const rowH =
+						ROW_ASCENT + (maxLines - 1) * BODY_LH + ROW_DESCENT;
+					needSpace(rowH + 1);
+
+					// ruleY = top edge of this row; rows touch exactly so there is
+					// no gap for the background-fill of the next row to cover the rule
+					const ruleY = y + ROW_ASCENT;
+
+					// Row background
+					parts.push(
+						`q\n${row.header ? "0.910 0.918 0.926 rg" : "0.980 0.982 0.984 rg"}\n` +
+							`${MX} ${ruleY - rowH} ${CW} ${rowH} re f\nQ\n`,
+					);
+
+					// Top rule drawn after fill so it is not covered
+					const ruleThick = isFirstBody ? "0.8" : "0.4";
+					parts.push(
+						`q\n${C_RULE} RG\n${ruleThick} w\n` +
+							`${MX} ${ruleY} m ${MX + CW} ${ruleY} l S\nQ\n`,
+					);
+
+					// Cell text
+					let colX = MX;
+					wrapped.forEach((lines, ci) => {
+						const cx = colX + HPAD;
+						lines.forEach((wl, li) => {
+							if (!wl.spans.some((s) => s.text)) return;
+							parts.push(`BT\n${cx} ${y - li * BODY_LH} Td\n`);
+							for (const sp of wl.spans) {
+								if (!sp.text) continue;
+								const isCode = sp.code && !row.header;
+								const font = isCode
+									? codeFont(sp.bold)
+									: bodyFont(
+											row.header || sp.bold,
+											sp.italic,
+										);
+								const color = isCode
+									? C_CODE
+									: sp.del
+										? C_DEL
+										: sp.link
+											? pdfRgb("#0969da")
+											: row.header
+												? C_HEAD
+												: C_BODY;
+								parts.push(
+									`/${font} ${BODY_FS} Tf\n${color} rg (${esc(sp.text)}) Tj\n`,
+								);
+							}
+							parts.push(`ET\n`);
+						});
+						colX += colWs[ci];
+					});
+
+					// Vertical column separators
+					colX = MX;
+					for (let ci = 0; ci < colCount - 1; ci++) {
+						colX += colWs[ci];
+						parts.push(
+							`q\n${C_RULE} RG\n0.4 w\n` +
+								`${colX} ${ruleY - rowH} m ${colX} ${ruleY} l S\nQ\n`,
+						);
+					}
+
+					y -= rowH;
+				}
+
+				// Bottom border
+				parts.push(
+					`q\n${C_RULE} RG\n0.4 w\n` +
+						`${MX} ${y + ROW_ASCENT} m ${MX + CW} ${y + ROW_ASCENT} l S\nQ\n`,
+				);
+
 				emitParagraphSpacing();
 				break;
 			}

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,64 +1,15 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { randomBytes } from "crypto";
-import { TokenMatch } from "./syntax/types";
-import { tokenizeKdl } from "./syntax/kdl";
-import { tokenizeAsp } from "./syntax/asp";
-import { tokenizeRazorVb } from "./syntax/razorVb";
-import { tokenizePhpSql } from "./syntax/phpSql";
-import { tokenizeJsSql } from "./syntax/jsSql";
-import { tokenizeNginx } from "./syntax/nginx";
 import { assemblePdf, CODE_PDF_FONTS, PdfImage } from "./pdfAssembler";
 import { renderMarkdownToHtml } from "./markdownRenderer";
 import { buildMarkdownPdfPages, MARKDOWN_PDF_FONTS } from "./markdownToPdf";
-
-// ─── Token colour palette (mirrors syntaxHighlighting.ts TOKEN_STYLES) ────────
-const TOKEN_COLORS: Record<string, string> = {
-	comment: "#57A64A",
-	string: "#D69D85",
-	number: "#B5CEA8",
-	boolean: "#569CD6",
-	typeAnnotation: "#4EC9B0",
-	nodeName: "#4FC1FF",
-	propKey: "#9CDCFE",
-	keyword: "#569CD6",
-	vbType: "#4EC9B0",
-	htmlTag: "#569CD6",
-	htmlAttribute: "#FF8C69",
-	htmlString: "#D69D85",
-	aspDelimiter: "#DCDCAA",
-	razorDelimiter: "#DCDCAA",
-	razorDirective: "#CE9178",
-	sqlKeyword: "#569CD6",
-	sqlType: "#4EC9B0",
-	sqlFunction: "#DCDCAA",
-	sqlVariable: "#9CDCFE",
-	nginxVariable: "#9CDCFE",
-	nginxBlock: "#4EC9B0",
-};
-const TOKEN_BOLD = new Set([
-	"nodeName",
-	"aspDelimiter",
-	"razorDelimiter",
-	"nginxBlock",
-]);
-const TOKEN_ITALIC = new Set(["comment", "razorDirective"]);
-
-// ─── File-extension → tokenizer map ──────────────────────────────────────────
-const TOKENIZERS: Array<{
-	extensions: string[];
-	tokenize: (text: string) => TokenMatch[];
-}> = [
-	{ extensions: [".kdl"], tokenize: tokenizeKdl },
-	{ extensions: [".asp"], tokenize: tokenizeAsp },
-	{ extensions: [".vbhtml"], tokenize: tokenizeRazorVb },
-	{ extensions: [".php"], tokenize: tokenizePhpSql },
-	{
-		extensions: [".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"],
-		tokenize: tokenizeJsSql,
-	},
-	{ extensions: [".conf"], tokenize: tokenizeNginx },
-];
+import {
+	StyledRun,
+	CODE_TOKENIZERS as TOKENIZERS,
+	buildStyledRuns,
+	runsToLines,
+} from "./codeTokenizer";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -68,13 +19,6 @@ function escapeHtml(text: string): string {
 		.replace(/</g, "&lt;")
 		.replace(/>/g, "&gt;")
 		.replace(/"/g, "&quot;");
-}
-
-interface StyledRun {
-	text: string;
-	color?: string;
-	bold?: boolean;
-	italic?: boolean;
 }
 
 // ─── Code PDF page builder ────────────────────────────────────────────────────
@@ -509,12 +453,21 @@ function buildMermaidPage(markdownHtml: string): string {
 	// <div class="mermaid">…</div>, unescaping HTML entities.
 	const withMermaid = markdownHtml.replace(
 		/<pre><code class="language-mermaid">([\s\S]*?)<\/code><\/pre>/gi,
-		(_, src: string) =>
-			`<div class="mermaid">${src
+		(_, src: string) => {
+			const decoded = src
 				.replace(/&amp;/g, "&")
 				.replace(/&lt;/g, "<")
 				.replace(/&gt;/g, ">")
-				.replace(/&quot;/g, '"')}</div>`,
+				.replace(/&quot;/g, '"');
+			// Quote participant/actor alias labels that contain chars Mermaid
+			// cannot accept in an unquoted label (e.g. / < > ( ) { }).
+			const fixed = decoded.replace(
+				/^(\s*(?:participant|actor)\s+\S+\s+as\s+)(?!")(.*\S)/gm,
+				(m, prefix: string, label: string) =>
+					/[/<>(){}]/.test(label) ? `${prefix}"${label}"` : m,
+			);
+			return `<div class="mermaid">${fixed}</div>`;
+		},
 	);
 
 	// Nonce-based CSP: CDN scripts allowed; inline scripts only via nonce
@@ -662,51 +615,6 @@ async function generateAndSavePdf(
 
 	await vscode.workspace.fs.writeFile(saveUri, pdfBuffer);
 	await vscode.env.openExternal(saveUri);
-}
-
-/** Converts source text + token list into styled run objects. */
-function buildStyledRuns(text: string, tokens: TokenMatch[]): StyledRun[] {
-	const sorted = [...tokens].sort((a, b) => a.start - b.start);
-	const runs: StyledRun[] = [];
-	let pos = 0;
-
-	for (const token of sorted) {
-		if (pos < token.start) {
-			runs.push({ text: text.slice(pos, token.start) });
-		}
-		runs.push({
-			text: text.slice(token.start, token.end),
-			color: TOKEN_COLORS[token.type],
-			bold: TOKEN_BOLD.has(token.type) || undefined,
-			italic: TOKEN_ITALIC.has(token.type) || undefined,
-		});
-		pos = token.end;
-	}
-
-	if (pos < text.length) {
-		runs.push({ text: text.slice(pos) });
-	}
-
-	return runs;
-}
-
-/** Splits an array of styled runs into per-line arrays, respecting multi-line tokens. */
-function runsToLines(runs: StyledRun[]): StyledRun[][] {
-	const lines: StyledRun[][] = [[]];
-
-	for (const run of runs) {
-		const parts = run.text.split("\n");
-		for (let i = 0; i < parts.length; i++) {
-			if (i > 0) {
-				lines.push([]);
-			}
-			if (parts[i].length > 0) {
-				lines[lines.length - 1].push({ ...run, text: parts[i] });
-			}
-		}
-	}
-
-	return lines;
 }
 
 function renderRun(run: StyledRun): string {
@@ -950,7 +858,49 @@ export function registerPrintCommand(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			"theToyBox.printFile",
-			(uri?: vscode.Uri) => openPrintPanel(context, uri),
+			async (uri?: vscode.Uri) => {
+				const enabled = vscode.workspace
+					.getConfiguration("theToyBox.print")
+					.get<boolean>("enabled", true);
+				if (!enabled) {
+					vscode.window.showInformationMessage(
+						'The Toy Box: Printing is disabled. Enable it in Settings under "Toy Box › Print: Enabled".',
+					);
+					return;
+				}
+
+				let document: vscode.TextDocument | undefined;
+				if (uri) {
+					try {
+						document = await vscode.workspace.openTextDocument(uri);
+					} catch {
+						vscode.window.showWarningMessage(
+							"The Toy Box: Could not open file for printing.",
+						);
+						return;
+					}
+				} else {
+					document = vscode.window.activeTextEditor?.document;
+				}
+
+				if (!document) {
+					vscode.window.showWarningMessage(
+						"The Toy Box: No file to save as PDF.",
+					);
+					return;
+				}
+
+				const fileName = document.fileName
+					? path.basename(document.fileName)
+					: "Untitled";
+
+				await generateAndSavePdf(
+					fileName,
+					document.languageId,
+					document.getText(),
+					context,
+				);
+			},
 		),
 	);
 

--- a/src/syntax/http.ts
+++ b/src/syntax/http.ts
@@ -1,0 +1,95 @@
+import type { TokenMatch } from "./types.js";
+
+// Token types: httpMethod, httpPath, httpVersion, httpStatus2xx,
+//              httpStatus4xx, httpHeaderName, httpHeaderValue, httpParamKey
+
+const METHODS_RE =
+	/^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE)(\s+)(\S+)(\s+)(HTTP\/[\d.]+)/i;
+const VERSION_RE = /^(HTTP\/[\d.]+)(\s+)(\d{3})/i;
+const HEADER_NAME_RE = /^[\w-]+$/;
+const QUERY_BODY_RE = /(?:^|&)([^&=\s]+)(?==)/g;
+
+export function tokenizeHttp(text: string): TokenMatch[] {
+	const tokens: TokenMatch[] = [];
+	const lines = text.split("\n");
+	let offset = 0;
+
+	for (const line of lines) {
+		let m: RegExpExecArray | null;
+
+		// Request line: METHOD /path HTTP/x.x
+		m = METHODS_RE.exec(line);
+		if (m) {
+			let p = offset;
+			tokens.push({ start: p, end: p + m[1].length, type: "httpMethod" });
+			p += m[1].length + m[2].length;
+			tokens.push({ start: p, end: p + m[3].length, type: "httpPath" });
+			p += m[3].length + m[4].length;
+			tokens.push({
+				start: p,
+				end: p + m[5].length,
+				type: "httpVersion",
+			});
+			offset += line.length + 1;
+			continue;
+		}
+
+		// Response status line: HTTP/x.x 200 OK
+		m = VERSION_RE.exec(line);
+		if (m) {
+			tokens.push({
+				start: offset,
+				end: offset + m[1].length,
+				type: "httpVersion",
+			});
+			const codeStart = offset + m[1].length + m[2].length;
+			const statusType =
+				parseInt(m[3]) < 300 ? "httpStatus2xx" : "httpStatus4xx";
+			tokens.push({
+				start: codeStart,
+				end: codeStart + m[3].length,
+				type: statusType,
+			});
+			offset += line.length + 1;
+			continue;
+		}
+
+		// Header field: Name: value
+		const ci = line.indexOf(":");
+		if (ci > 0 && HEADER_NAME_RE.test(line.slice(0, ci))) {
+			tokens.push({
+				start: offset,
+				end: offset + ci,
+				type: "httpHeaderName",
+			});
+			if (ci + 1 < line.length) {
+				tokens.push({
+					start: offset + ci + 1,
+					end: offset + line.length,
+					type: "httpHeaderValue",
+				});
+			}
+			offset += line.length + 1;
+			continue;
+		}
+
+		// URL-encoded body or query string: key=value&key=value
+		if (/\w+=/.test(line)) {
+			QUERY_BODY_RE.lastIndex = 0;
+			let km: RegExpExecArray | null;
+			while ((km = QUERY_BODY_RE.exec(line)) !== null) {
+				// km[1] is the key; it may start after a leading `&`
+				const keyStart = km.index + (km[0].startsWith("&") ? 1 : 0);
+				tokens.push({
+					start: offset + keyStart,
+					end: offset + keyStart + km[1].length,
+					type: "httpParamKey",
+				});
+			}
+		}
+
+		offset += line.length + 1;
+	}
+
+	return tokens;
+}

--- a/src/syntax/shell.ts
+++ b/src/syntax/shell.ts
@@ -1,0 +1,44 @@
+import type { TokenMatch } from "./types.js";
+
+// Token types: comment, shellVar, shellString, shellFlag, keyword
+
+// Patterns applied in priority order; earlier wins at any given position.
+const PATTERNS: Array<{ re: RegExp; type: string }> = [
+	{ re: /#.*/g, type: "comment" },
+	{ re: /\$\{[^}]*\}|\$[A-Za-z_]\w*/g, type: "shellVar" },
+	{ re: /"(?:[^"\\]|\\.)*"/g, type: "shellString" },
+	{ re: /'[^']*'/g, type: "shellString" },
+	{ re: /--?[\w][\w-]*/g, type: "shellFlag" },
+	{
+		re: /\b(?:if|then|else|elif|fi|for|while|do|done|case|esac|in|function|return|export|local|readonly|declare|source|unset|shift|echo|printf|exit|break|continue|true|false)\b/g,
+		type: "keyword",
+	},
+];
+
+export function tokenizeShell(text: string): TokenMatch[] {
+	// Track which character positions have already been claimed.
+	const claimed = new Uint8Array(text.length);
+	const tokens: TokenMatch[] = [];
+
+	for (const { re, type } of PATTERNS) {
+		re.lastIndex = 0;
+		let m: RegExpExecArray | null;
+		while ((m = re.exec(text)) !== null) {
+			const start = m.index;
+			const end = start + m[0].length;
+			// Skip if any position in this range is already claimed.
+			let overlap = false;
+			for (let i = start; i < end; i++) {
+				if (claimed[i]) {
+					overlap = true;
+					break;
+				}
+			}
+			if (overlap) continue;
+			for (let i = start; i < end; i++) claimed[i] = 1;
+			tokens.push({ start, end, type });
+		}
+	}
+
+	return tokens.sort((a, b) => a.start - b.start);
+}


### PR DESCRIPTION
- Fix: Ensure tables in Markdown render correctly when exporting to PDF, regardless of line endings.
- Improve: Enhance table layout and styling in PDF exports, including better column sizing and consistent cell padding.
- Feature: Add syntax highlighting for HTTP and Shell/Bash code blocks in PDF exports.
- Fix: Correct rendering of Mermaid diagrams with blank lines in PDF exports.
- Update README to reflect new features and improvements in PDF export functionality.
- Update package version to 1.1.9 and add new language identifiers for syntax highlighting.
- Refactor code to introduce a shared code tokenizer for improved syntax highlighting across different file types.
- Normalize line endings in Markdown rendering to ensure consistent processing.